### PR TITLE
swapped the GET method for the more specific google drive .get call

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,29 +125,36 @@
         });
       }
 
+      //Pulls file Meta Data object and prints it to log
       function getFileMetadata(id){
          console.log("getFileMetadata(" + id + ")");
-         var request = gapi.client.request({
-           'method': 'GET',
-           'path': '/drive/v3/files/' + id
-         });
-
-         request.execute(function(response) {
-            console.log(response);
+         //Request to access gapi for drive "gapi.client.drive.files" specifies the API to use, 
+         //the .get method is the standard Google drive GET method
+         //'fileId' is the file's ID value in string format
+         //'fields' allows for specific subfields to be pulled by listing which ones you want delimitted by a space, with '*' pulling all fields
+         var request = gapi.client.drive.files.get({
+            'fileId': id, 'fields': "*"
+          })
+          //Executes API request, outputting object to 'response'
+            request.execute(function(response) {
+              console.log(response);
          });
       }
 
+      //Pulls Permissions subfield from file metadata and logs the object to console
       function getFilePermissions(id){
          console.log("getFilePermissions(" + id + ")");
-         var request = gapi.client.request({
-           'method': 'GET',
-           'path': '/drive/v3/files/' + id + '/permissions'
-         });
-
+         var request = gapi.client.drive.files.get({
+            'fileId': id, 'fields': "permissions"
+          })
          request.execute(function(response) {
-            console.log(response);
+           let perMetaDataObj = response;
+           let perObj = perMetaDataObj.permissions;
+           let permissions = perObj[0];
+            console.log(permissions);
          });
       }
+
     </script>
 
   </head>

--- a/src/components/Upload.vue
+++ b/src/components/Upload.vue
@@ -43,7 +43,6 @@
   </div>
 </template>
 
-
 <script>
 export default {
   name: 'upload',


### PR DESCRIPTION
made the gapi call pull the entire metadata file, instead of the std 4 fields, and return it to console
The getPermissions method now retrieves just the permissions object and returns it to the console
added comments on how to structure the more specific call 
*Thanks go to Derek on the drive API lesson